### PR TITLE
feat: Enhance MongoDB setup function to check for existing container

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -109,11 +109,22 @@ load_env() {
 
 # ────────────────────────── MongoDB Setup ────────────────────────────
 run_mongo_container() {
+    local container_name="mongo-container"
+
+    # Check if container exists, stop and remove it
+    if docker ps -a --filter "name=^/${container_name}$" --format "{{.Names}}" | grep -q "^${container_name}$"; then
+        echo "Container ${container_name} already exists. Stopping and removing it..."
+        docker stop ${container_name} >/dev/null 2>&1
+        docker rm ${container_name} >/dev/null 2>&1
+    fi
+
     # Run the MongoDB container in detached mode
-    docker run -d --name mongo-container -p 27017:27017 mongo:latest
+    echo "Creating new MongoDB container..."
+    docker run -d --name ${container_name} -p 27017:27017 mongo:latest
 
     # Output the connection string
     echo "mongodb://admin:password@localhost:27017/"
+    echo "Container started successfully."
 }
 
 # ────────────────────────── Prompt Setup ────────────────────────────


### PR DESCRIPTION
This update improves the MongoDB container setup by first checking if a container named "mongo-container" already exists. If it does, the script stops and removes the existing container before launching a new instance. This approach prevents duplicate containers and avoids potential port conflicts, ensuring a smoother setup process.

- **Changes Made:**  
  - Added logic to detect an existing MongoDB container.  
  - Stops and removes the container if it’s already running.  
  - Launches a fresh MongoDB container and outputs the connection string.

- **Benefits:**  
  - Ensures a clean environment for MongoDB each time the setup runs.  
  - Reduces issues related to stale containers and port usage.

- **Notes:**  
  - Please verify that this approach meets your deployment needs.  
  - Contributions should adhere to the GitHub Community Guidelines.